### PR TITLE
Extend compatibility back to python>=3.8

### DIFF
--- a/fppanalysis/__init__.py
+++ b/fppanalysis/__init__.py
@@ -12,4 +12,4 @@ from .random_phase import *
 from .binning_container import *
 from .parameter_estimation_ECF import *
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -38,7 +38,7 @@ numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
 name = "tqdm"
-version = "4.62.3"
+version = "4.63.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = false
@@ -54,8 +54,8 @@ telegram = ["requests"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.10,<3.11"
-content-hash = "4e731f90a0c8b9a790179ef76d3128cb7da97800e0fa5c9372ce45fcef7f35ab"
+python-versions = ">=3.8,<3.11"
+content-hash = "69a3913cac00cb4d9bc9ce2d675a489f120803d0d6000ab9c740a35702f805c7"
 
 [metadata.files]
 colorama = [
@@ -149,6 +149,6 @@ scipy = [
     {file = "scipy-1.8.0.tar.gz", hash = "sha256:31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd"},
 ]
 tqdm = [
-    {file = "tqdm-4.62.3-py2.py3-none-any.whl", hash = "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c"},
-    {file = "tqdm-4.62.3.tar.gz", hash = "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"},
+    {file = "tqdm-4.63.0-py2.py3-none-any.whl", hash = "sha256:e643e071046f17139dea55b880dc9b33822ce21613b4a4f5ea57f202833dbc29"},
+    {file = "tqdm-4.63.0.tar.gz", hash = "sha256:1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fppanalysis"
-version = "0.1.0"
+version = "0.1.1"
 description = "Analysis tools for time series"
 homepage = "https://github.com/uit-cosmo/fpp-analysis-tools"
 authors = ["gregordecristoforo <gregor.decristoforo@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.11"
-numpy = "^1.22.2"
+python = ">=3.8,<3.11"
+numpy = "^1.18"
 scipy = "^1.8.0"
 tqdm = "^4.62.3"
 PyWavelets = "^1.2.0"


### PR DESCRIPTION
I think I was a bit too quick on the initial creation of the `pyproject.toml` file. Should probably accept a bit more versions. E.g., `numba` need `numpy<1.22`.

This PR will allow `numpy>=1.18` and `python>=3.8`, making is work with the current version of `numba` (`0.55.1`).