### PR TITLE
set print_verbose=False in cond_av method in time_delay_estimation function

### DIFF
--- a/fppanalysis/time_delay_estimation.py
+++ b/fppanalysis/time_delay_estimation.py
@@ -249,6 +249,7 @@ def estimate_time_delay_ccond_av_max(
         Sref=y,
         delta=delta,
         window=window,
+        print_verbose=False,
     )
     max_index = np.argmax(s_av)
 


### PR DESCRIPTION
Set print_verbose=False in cond_av method in time_delay_estimation function to avoid several prints when computing vector field. 