### PR TITLE
Implement interpolation for finding ccf maximum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Editor
 .idea/
+
+# Debug
+/debug

--- a/fppanalysis/time_delay_estimation.py
+++ b/fppanalysis/time_delay_estimation.py
@@ -213,6 +213,56 @@ def estimate_time_delay_ccmax(x: np.ndarray, y: np.ndarray, dt: float):
     return ccf_times[max_index], ccf[max_index]
 
 
+def estimate_time_delay_ccmax_interpolate(x: np.ndarray, y: np.ndarray, dt: float):
+    """Estimates the average time delay between to signals by finding the time
+    lag that maximizes the interpolated cross-correlation function. By using
+    interpolation, the returned time does not need to be an integer multiple of dt.
+
+    Returns:
+        td Estimated time delay
+        C Cross correlation at a time lag td.
+    """
+    ccf_times, ccf = cf.corr_fun(x, y, dt=dt, biased=True, norm=True)
+    ccf = ccf[np.abs(ccf_times) < max(ccf_times) / 2]
+    ccf_times = ccf_times[np.abs(ccf_times) < max(ccf_times) / 2]
+    max_index = np.argmax(ccf)
+    max_time, ccf_value = ccf_times[max_index], ccf[max_index]
+
+    # If the maximum is very close to the origin, we make an interpolation window of 20 discretization times in
+    # each direction, otherwise, the interpolation window is twice the time maximum in each direction.
+    interpolation_window_boundary = (
+        20 * dt if np.abs(max_time) < 10 * dt else np.abs(max_time) * 2
+    )
+    interpolation_window = np.abs(ccf_times) < interpolation_window_boundary
+
+    max_time_interpolate = _find_maximum_interpolate(
+        ccf_times[interpolation_window], ccf[interpolation_window]
+    )
+
+    return max_time_interpolate, ccf_value
+
+
+def _find_maximum_interpolate(x, y):
+    from scipy.interpolate import InterpolatedUnivariateSpline
+
+    # Taking the derivative and finding the roots only work if the spline degree is at least 4.
+    spline = InterpolatedUnivariateSpline(x, y, k=4)
+    possible_maxima = spline.derivative().roots()
+    possible_maxima = np.append(
+        possible_maxima, (x[0], x[-1])
+    )  # also check the endpoints of the interval
+    values = spline(possible_maxima)
+
+    max_index = np.argmax(values)
+    if possible_maxima[max_index] == x[0] or possible_maxima[max_index] == x[-1]:
+        import warnings
+
+        warnings.warn(
+            "Maximization on interpolation yielded a maximum in the boundary!"
+        )
+    return possible_maxima[max_index]
+
+
 def estimate_time_delay_ccond_av_max(
     x: np.ndarray,
     x_t: np.ndarray,

--- a/fppanalysis/two_dim_velocity_estimates.py
+++ b/fppanalysis/two_dim_velocity_estimates.py
@@ -260,7 +260,9 @@ def estimate_velocities_for_pixel(
     ignored. Pixels outside the coordinate domain are ignored. Time delay
     estimation is performed by maximizing either the cross- correlation
     function or cross conditional average function, which is specified in input
-    argument 'method'.
+    argument 'method'. Setting 'method'='cross_corr_interpolate' will let interpolate
+    the cross-correlation function to find the maximum so that it is not
+    restricted to a multiple of the discretization time.
 
     If time delay estimation is performed by maximizing the cross correlation function,
     the confidence of the estimation is a value in the interval (0, 1) given by the
@@ -275,7 +277,7 @@ def estimate_velocities_for_pixel(
         x: pixel index x
         y: pixel index y
         ds: xarray Dataset
-        method: 'cross_corr' or 'cond_av'
+        method: 'cross_corr' or 'cond_av' or 'cross_corr_interpolate'
         kwargs: kwargs used in 'cond_av'
             - min_threshold: min threshold for conditional averaged events
             - max_threshold: max threshold for conditional averaged events
@@ -325,7 +327,9 @@ def estimate_velocity_field(
     neighbour. The velocities are estimated from a time delay estimation
     performed by maximizing either the cross- correlation function or cross
     conditional average function, which is specified in input argument
-    'method'.
+    'method'. Setting 'method'='cross_corr_interpolate' will let interpolate
+    the cross-correlation function to find the maximum so that it is not
+    restricted to a multiple of the discretization time.
 
     If time delay estimation is performed by maximizing the cross correlation function,
     the confidence of the estimation is a value in the interval (0, 1) given by the
@@ -341,7 +345,7 @@ def estimate_velocity_field(
 
     Input:
         ds: xarray Dataset
-        method: 'cross_corr' or 'cond_av'
+        method: 'cross_corr' or 'cond_av' or 'cross_corr_interpolate'
         kwargs: kwargs used in 'cond_av'
             - min_threshold: min threshold for conditional averaged events
             - max_threshold: max threshold for conditional averaged events

--- a/fppanalysis/two_dim_velocity_estimates.py
+++ b/fppanalysis/two_dim_velocity_estimates.py
@@ -178,24 +178,26 @@ def _estimate_time_delay(
     dt: float,
     **kwargs: dict
 ):
-
-    if method == "cross_corr":
-        (delta_t, c), events = tde.estimate_time_delay_ccmax(x=x, y=y, dt=dt), 0
-
-    elif method == "cond_av":
-        delta_t, c, events = tde.estimate_time_delay_ccond_av_max(
-            x=x,
-            x_t=x_t,
-            y=y,
-            min_threshold=kwargs["min_threshold"],
-            max_threshold=kwargs["max_threshold"],
-            delta=kwargs["delta"],
-            window=kwargs["window"],
-        )
-
-    else:
-        raise Exception("Method must be either cross_corr or cond_av")
-
+    match method:
+        case "cross_corr_interpolate":
+            (delta_t, c), events = (
+                tde.estimate_time_delay_ccmax_interpolate(x=x, y=y, dt=dt),
+                0,
+            )
+        case "cross_corr":
+            (delta_t, c), events = tde.estimate_time_delay_ccmax(x=x, y=y, dt=dt), 0
+        case "cond_av":
+            delta_t, c, events = tde.estimate_time_delay_ccond_av_max(
+                x=x,
+                x_t=x_t,
+                y=y,
+                min_threshold=kwargs["min_threshold"],
+                max_threshold=kwargs["max_threshold"],
+                delta=kwargs["delta"],
+                window=kwargs["window"],
+            )
+        case _:
+            raise Exception("Method must be either cross_corr or cond_av")
     return delta_t, c, events
 
 

--- a/tests/two_dim_velocity_estimates_test.py
+++ b/tests/two_dim_velocity_estimates_test.py
@@ -143,3 +143,16 @@ def test_ignore_dead_pixels():
     )
     error = np.max([abs(v_est - v), abs(w_est - w)])
     assert error < 0.1, "Numerical error too big"
+
+
+def test_interpolate():
+    v, w = 1.2, 1
+    # Without interpolation, there is no enough time resolution (dt = 0.1) to find the cross-correlation maximum
+    ds = make_2d_realization(v, w, np.array([1, 1.1]), np.array([5, 5.1]), dt=0.1)
+    pd = td.estimate_velocities_for_pixel(1, 1, ds, method="cross_corr_interpolate")
+    v_est, w_est, = (
+        pd.vx,
+        pd.vy,
+    )
+    error = np.max([abs(v_est - v), abs(w_est - w)])
+    assert error < 0.1, "Numerical error too big"


### PR DESCRIPTION
I made some changes so that the cross-correlation maximum can be computed from a spline. This method is now available by setting method="cross_corr_interpolate". @auroradh Can you check that the code changes make sense? In addition, I believe this should have a minor (most likely unnoticeable) impact when applied on APD data, can you apply the new method, and check that the results are very similar to those obtained with method=cross_corr?