### PR TITLE
fix: version mismatch between pyproject and module

### DIFF
--- a/fppanalysis/__init__.py
+++ b/fppanalysis/__init__.py
@@ -12,4 +12,5 @@ from .random_phase import *
 from .binning_container import *
 
 from importlib.metadata import version
+
 __version__ = version(__package__)

--- a/fppanalysis/__init__.py
+++ b/fppanalysis/__init__.py
@@ -11,4 +11,5 @@ from .peak_detection import detect_peaks_1d
 from .random_phase import *
 from .binning_container import *
 
-__version__ = "0.1.6"
+from importlib.metadata import version
+__version__ = version(__package__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fppanalysis"
-version = "0.1.6"
+version = "0.1.7"
 description = "Analysis tools for time series"
 homepage = "https://github.com/uit-cosmo/fpp-analysis-tools"
 authors = ["gregordecristoforo <gregor.decristoforo@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fppanalysis"
-version = "0.1.5"
+version = "0.1.6"
 description = "Analysis tools for time series"
 homepage = "https://github.com/uit-cosmo/fpp-analysis-tools"
 authors = ["gregordecristoforo <gregor.decristoforo@gmail.com>"]


### PR DESCRIPTION
Pyproject.toml says 0.1.5, the module says 0.1.6.

Now uses the standard lib `importlib` to report the installed version.