### PR TITLE
chore: patch release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fppanalysis"
-version = "0.1.7"
+version = "0.1.8"
 description = "Analysis tools for time series"
 homepage = "https://github.com/uit-cosmo/fpp-analysis-tools"
 authors = ["gregordecristoforo <gregor.decristoforo@gmail.com>"]


### PR DESCRIPTION
Patch includes renaming fix for the deprecated scipy function simps, now simpson. (#50)